### PR TITLE
Actualizar URL y hash de la política de firma

### DIFF
--- a/src/CreadorXML.php
+++ b/src/CreadorXML.php
@@ -210,7 +210,7 @@ class CreadorXML
             }
         );
 
-        $sigPolicyId = 'https://atv.hacienda.go.cr/ATV/ComprobanteElectronico/docs/esquemas/2016/v4.3/Resoluci%C3%B3n_General_sobre_disposiciones_t%C3%A9cnicas_comprobantes_electr%C3%B3nicos_para_efectos_tributarios.pdf';
+        $sigPolicyId = 'https://cdn.comprobanteselectronicos.go.cr/xml-schemas/Resoluci%C3%B3n_General_sobre_disposiciones_t%C3%A9cnicas_comprobantes_electr%C3%B3nicos_para_efectos_tributarios.pdf';
         $sigPolicyHash = 'DWxin1xWOeI8OuWQXazh4VjLWAaCLAA954em7DMh0h8='; //hash en sha256
         // CALCULADO CON sha256sum sobre el archivo descargado
         // echo {sha256sum} | xxd -r -p | base64

--- a/src/CreadorXML.php
+++ b/src/CreadorXML.php
@@ -211,7 +211,7 @@ class CreadorXML
         );
 
         $sigPolicyId = 'https://atv.hacienda.go.cr/ATV/ComprobanteElectronico/docs/esquemas/2016/v4.3/Resoluci%C3%B3n_General_sobre_disposiciones_t%C3%A9cnicas_comprobantes_electr%C3%B3nicos_para_efectos_tributarios.pdf';
-        $sigPolicyHash = '0h7Q3dFHhu0bHbcZEgVc07cEcDlquUeG08HG6Iototo='; //hash en sha256
+        $sigPolicyHash = 'DWxin1xWOeI8OuWQXazh4VjLWAaCLAA954em7DMh0h8='; //hash en sha256
         // CALCULADO CON sha256sum sobre el archivo descargado
         // echo {sha256sum} | xxd -r -p | base64
 


### PR DESCRIPTION
La Dirección General de Tributación actualiza la resolución de comprobantes de las versiones anteriores cuando actualiza para la próxima, es decir, el PDF de la resolución de la 4.4 también se ha actualizado para la URL de la 4.3, por lo que el hash ha cambiado. Para solucionarlo, este Pull Request incluye el hash del PDF de la resolución vigente publicada hace unas semanas.

Este tipo de modificación sucedió de manera similar entre la 4.2 y la 4.3, por lo que no es sorprendente. Esto es probablemente porque deroga la anterior resolución. Sin embargo, la URL es la misma y esto tiene un efecto adverso, ya que rompe la correcta validación EPES de la política de las facturas archivadas en los validadores conforme a XAdES-EPES, donde estos validadores ahora presentan un mensaje de aviso porque el hash comprobado en línea ya no coincide. El validador conforme a EPES descarga el PDF desde la URL, genera el hash y lo compara con el del XML.

Cuando sucedió esto con la 4.3 se escribió a FacturaTI para que no modificaran los PDF de URLs existentes y lanzaran las actualizaciones de resolución en una URL diferente (algo con sufijo v2 o similar), pero se puede observar que no siguieron la recomendación. Para que las facturas validen correctamente en validadores conforme a EPES se recomienda aplicar este cambio cuanto antes mejor.

Normalmente se podría validar si el hash de la policy es correcto en el validador de firmador.libre.cr, pero hoy día posiblemente el User-Agent del cliente HTTP de este validador (Apache HTTPClient 5.x) lo bloquee el pseudocortafuegos del servidor de Hacienda (usan una "protección" de Akamai) al tratar  de descargar el PDF, por lo que no resultaría muy eficaz para ver la diferencia sin antes realizar modificaciones en el cliente HTTP de un validador conforme a EPES para simular ser Chrome, Firefox o similares de versiones actualizadas. De todos modos aparentemente eliminaron algunas restricciones de versiones, puede intentar usarse de todos modos. Otra opción en línea es https://validador.libre.cr que es un validador web que no requiere instalación. Tenga en cuenta que en cualquiera de estas dos modalidades de validación, los certificados de Hacienda aparecerán como indeterminados porque no están emitidos por la jerarquía del Micitt (no cumplen con la ley de certificados) y aparecerá un mensaje adicional de que se desconoce el certificado, pero sí se observará la diferencia entre un XML con el hash anterior y el nuevo, donde desaparecerá uno de los mensajes de advertencia al respecto (siempre que el servidor de Hacienda no bloquee la descarga del PDF).