### PR TITLE
Mejorar logging de errores en Token para facilitar diagnóstico

### DIFF
--- a/src/Token.php
+++ b/src/Token.php
@@ -140,11 +140,13 @@ class Token
                     $accessToken = $this->saveToken($body);
                     return $accessToken;
                 }
-            } catch (\GuzzleHttp\Exception\ClientException $_) {
+            } catch (\GuzzleHttp\Exception\ClientException $e) {
                 //error de cliente
                 //Datos incorrectos de autenticacion
+                $code = $e->getResponse()->getStatusCode();
+                $body = $e->getResponse()->getBody()->getContents();
                 $this->container->logger->info(
-                    "Fallo 40x consiguiendo token para {$this->cedula}",
+                    "Fallo {$code} consiguiendo token para {$this->cedula}. Respuesta: {$body}",
                 );
                 $ratelimiter->registerTransaction(
                     $this->id,
@@ -202,10 +204,12 @@ class Token
                     $accessToken = $this->saveToken($body);
                     return $accessToken;
                 }
-            } catch (\GuzzleHttp\Exception\ClientException $_) {
+            } catch (\GuzzleHttp\Exception\ClientException $e) {
                 //a 400 error
+                $code = $e->getResponse()->getStatusCode();
+                $body = $e->getResponse()->getBody()->getContents();
                 $this->container->logger->info(
-                    "Fallo 40x refrescando token para {$this->cedula}",
+                    "Fallo {$code} refrescando token para {$this->cedula}. Respuesta: {$body}",
                 );
                 $ratelimiter->registerTransaction(
                     $this->cedula,


### PR DESCRIPTION
Actualmente los mensajes de error en newToken() y refreshToken() registran un genérico "Fallo 40x", lo cual dificulta diagnosticar problemas de autenticación con el IDP de Hacienda.

Este cambio captura el código HTTP real y el cuerpo de la respuesta desde la excepción, brindando información más útil para el diagnóstico:

newToken(): Ahora registra el código HTTP específico y el cuerpo de la respuesta
refreshToken(): Misma mejora
Esto permite identificar si el fallo es un 401 (credenciales incorrectas), 403 (usuario bloqueado), u otro error 4xx, junto con el detalle exacto que devuelve Hacienda.